### PR TITLE
reduce MTU to 1100 (arbitrarily) to work around issues with path MTU …

### DIFF
--- a/roles/conduit/templates/interfaces.j2
+++ b/roles/conduit/templates/interfaces.j2
@@ -22,6 +22,8 @@ iface eth0 inet {{ eth0_type }}
 {% endif %}
     post-up ln -sf {{ resolv_conf_static }} /etc/resolv.conf
 {% endif %}
+    # always reduce the MTU in case path mtu isn't working
+    post-up ifconfig eth0 mtu 1100
 {% endif %}
 
 {% if br0_type is defined and br0_type %}


### PR DESCRIPTION
…discovery (#20). This change simply adds code to the interfaces template to hard-code the MTU at 1100. Of course, this might better be a parameter (with an entry in `defaults.yml`, possibly overridden as a group policy, and further possibly overridden on a host-by-host basis).