### PR TITLE
Add better support for external databases of gateways

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,19 @@ OPTIONS=
 
 #
 # figure out the inventory.
-#  - if INVENTORY is given from the command line or env, just use it
+#  - if ORG is given from the command line or env, set INVENTORY to
+#    ${ORG}/inventory and CATALOG to ${ORG}/catalog
+#  - Otherwise, if INVENTORY is given from the command line or env, just use it
 #    (and use CATALOG)
 #  - Otherwise, if there's a hosts file in this directory, use it
 #  - Otherwise, if there's a directory ../inventory, use it
 #  - Otherwise complain and quit.
 #
+ifneq ($(ORG),)
+ INVENTORY=${ORG}/inventory
+ CATALOG=${ORG}/catalog
+endif
+
 ifeq ($(INVENTORY),)
  ifneq ($(wildcard hosts),)
    INVENTORY=hosts
@@ -52,9 +59,7 @@ ifeq ($(INVENTORY),)
    $(error Can't find an inventory file)
  endif
 else
- ifeq ($(wildcard $(INVENTORY)/.),)
-   $(error not a directory: $(INVENTORY))
- else ifeq ($(CATALOG),)
+ ifeq ($(CATALOG),)
    ifneq ($(wildcard $(dir $(INVENTORY))/catalog/.),)
      CATALOG=$(dir $(INVENTORY))
    else
@@ -63,7 +68,10 @@ else
  endif
 endif
 
-# another idiot check.
+# santity checks.
+ifeq ($(wildcard $(INVENTORY)/.),)
+   $(error not a directory: $(INVENTORY))
+endif
 ifeq ($(wildcard $(CATALOG)/.),)
    $(error not a directory: $(CATALOG))
 endif

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ OPTIONS=
 
 #
 # figure out the inventory.
-#  - if MY_INVENTORY is given from the command line or env, just use it.
+#  - if INVENTORY is given from the command line or env, just use it
+#    (and use CATALOG)
 #  - Otherwise, if there's a hosts file in this directory, use it
 #  - Otherwise, if there's a directory ../inventory, use it
 #  - Otherwise complain and quit.

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,38 @@ clean::	true
 	done
 
 
-# Where we keep a catalog of conduit configuration
-CATALOG=catalog
-
 # List of tags to limit playbook
 export TAGS=
 # Target or group
 export TARGET=conduits
 TIMEOUT=60
-INVENTORY=hosts
 OPTIONS=
+
+#
+# figure out the inventory.
+#  - if MY_INVENTORY is given from the command line or env, just use it.
+#  - Otherwise, if there's a hosts file in this directory, use it
+#  - Otherwise, if there's a directory ../inventory, use it
+#  - Otherwise complain and quit.
+#
+ifeq ($(INVENTORY),)
+ ifneq ($(wildcard hosts),)
+   INVENTORY=hosts
+   # Where we keep a catalog of conduit configuration
+   CATALOG=catalog
+ else ifneq ($(wildcard ../inventory/.),)
+   INVENTORY=../inventory
+   # Where we keep a catalog of conduit configuration
+   CATALOG=../catalog
+ else
+   $(error Can't find an inventory file)
+ endif
+endif
+
+# now that we know the inventory, get the hosts.
 HOSTS=$(shell ansible --inventory ${INVENTORY} --list-hosts ${TARGET} | sed -e 's/^ *//' -e '/^hosts ([0-9]*):/d')
+
+# set the default playbook parameters
 PLAYBOOK_ARGS=-T ${TIMEOUT} --inventory ${INVENTORY} $${TAGS:+-t $${TAGS}} $${TARGET:+-l $${TARGET}} ${OPTIONS}
 
 all::	apply

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,21 @@ ifeq ($(INVENTORY),)
  else
    $(error Can't find an inventory file)
  endif
+else
+ ifeq ($(wildcard $(INVENTORY)/.),)
+   $(error not a directory: $(INVENTORY))
+ else ifeq ($(CATALOG),)
+   ifneq ($(wildcard $(dir $(INVENTORY))/catalog/.),)
+     CATALOG=$(dir $(INVENTORY))
+   else
+     $(error Can't infer CATALOG from INVENTORY -- please supply CATALOG)
+   endif
+ endif
+endif
+
+# another idiot check.
+ifeq ($(wildcard $(CATALOG)/.),)
+   $(error not a directory: $(CATALOG))
 endif
 
 # now that we know the inventory, get the hosts.


### PR DESCRIPTION
This change adds 

- ability to run automatically when ttn-multitech-cm is a submodule of the organization database (using the data from the organization), and
- the (even better) ability to point ttn-muilttech-cm at an external organization database, using `ORG={dir}`.

It would be very helpful to have both forms, though the submodule form probably needs to be deprecated (and can easily be achieved with `ORG=..` after we remove the automatic version).

Note: the reason for deprecating automatic submodules is that I've found that having multiple copies of the repo around, while trying to track development, is painful; though for production once things get more final it may well be better (as it ties the database to a specific version). 