### PR TITLE
Clarify name of var for gateway user on jumphost

### DIFF
--- a/roles/conduit/README.md
+++ b/roles/conduit/README.md
@@ -48,8 +48,10 @@ Role Variables
 	<dd>Co-ordinates of this gateway</dd>
 	<dt>altitude</dt>
 	<dd>Altitude of this gateway in meters</dd>
-	<dt>ssh_tunnel_remote_user</dt>
-	<dd>User configured on the tunnel server</dd>
+	<dt>ssh_tunnel_gateway_user_on_jumphost</dt>
+	<dd>User configured on the tunnel server (for use by the gateway)</dd>
+	<dt>ssh_tunnel_ansible_user_on_jumphost</dt>
+	<dd>User configured on the tunnel server (for use by ansible)</dd>
 	<dt>ssh_tunnel_remote_host</dt>
 	<dd>Hostname or IP address of tunnel server</dd>
 	<dt>ssh_tunnel_ssh_key</dt>

--- a/roles/conduit/templates/ssh_tunnel.j2
+++ b/roles/conduit/templates/ssh_tunnel.j2
@@ -9,8 +9,8 @@ LOCAL_PORT={{ ssh_tunnel_local_port }}
 {% if ssh_tunnel_remote_host %}
 REMOTE_HOST={{ ssh_tunnel_remote_host }}
 {% endif %}
-{% if ssh_tunnel_remote_user %}
-REMOTE_USER={{ ssh_tunnel_remote_user }}
+{% if ssh_tunnel_gateway_user_on_jumphost %}
+REMOTE_USER={{ ssh_tunnel_gateway_user_on_jumphost }}
 {% endif %}
 {% if ssh_tunnel_remote_port %}
 REMOTE_PORT={{ ssh_tunnel_remote_port }}

--- a/roles/conduit/vars/main.yml
+++ b/roles/conduit/vars/main.yml
@@ -18,7 +18,7 @@ lora_hostname: "{{ hostname if forwarder_variant == 'mp' else lora_eui }}"
 lora_hostname_delete: "{{ lora_eui if forwarder_variant == 'mp' else hostname }}"
 
 # Is ssh_tunnel enabled
-ssh_tunnel_enabled: "{{ ssh_tunnel_remote_port is defined and ssh_tunnel_remote_port > 0 and ssh_tunnel_remote_user is defined }}"
+ssh_tunnel_enabled: "{{ ssh_tunnel_remote_port is defined and ssh_tunnel_remote_port > 0 and ssh_tunnel_gateway_user_on_jumphost is defined }}"
 
 # Is the GPS present?
 have_gps: "{{ gps_device in ansible_local.dev }}"

--- a/roles/sshhost/tasks/main.yml
+++ b/roles/sshhost/tasks/main.yml
@@ -4,23 +4,25 @@
 # XXX - Probably not necessary to create user
 # XXX - local_action to run script?
 #
-#	Create ssh user
+#	Create ssh user on jumphost. Note that the MCCI port-mapping
+# numbering scheme is not really handled here, so this will
+# usually be done by a separate script.
 #
-- name: "Set up {{ ssh_tunnel_remote_user }} user"
+- name: "Set up {{ ssh_tunnel_gateway_user_on_jumphost }} user"
   user:
-    name: "{{ ssh_tunnel_remote_user }}"
+    name: "{{ ssh_tunnel_gateway_user_on_jumphost }}"
     append: yes
     shell: /bin/bash
     password: "*"
   tags: users
 
-- name: Create {{ ssh_tunnel_remote_user }}  .ssh dir
+- name: Create {{ ssh_tunnel_gateway_user_on_jumphost }}  .ssh dir
   file:
-    dest: "~{{ ssh_tunnel_remote_user }}/.ssh"
+    dest: "~{{ ssh_tunnel_gateway_user_on_jumphost }}/.ssh"
     state: directory
     mode: "0700"
-    owner: "{{ ssh_tunnel_remote_user }}"
-    group: "{{ ssh_tunnel_remote_user }}"
+    owner: "{{ ssh_tunnel_gateway_user_on_jumphost }}"
+    group: "{{ ssh_tunnel_gateway_user_on_jumphost }}"
   tags: users
 
 - name: Create authorized keys
@@ -30,13 +32,13 @@
   tags: users
 
 # Using a template?
-- name: "Install {{ ssh_tunnel_remote_user }} authorized keys"
+- name: "Install {{ ssh_tunnel_gateway_user_on_jumphost }} authorized keys"
   copy:
-    dest: "~{{ ssh_tunnel_remote_user }}/.ssh/authorized_keys"
+    dest: "~{{ ssh_tunnel_gateway_user_on_jumphost }}/.ssh/authorized_keys"
     src: authorized_keys
     mode: "0600"
-    owner: "{{ ssh_tunnel_remote_user }}"
-    group: "{{ ssh_tunnel_remote_user }}"
+    owner: "{{ ssh_tunnel_gateway_user_on_jumphost }}"
+    group: "{{ ssh_tunnel_gateway_user_on_jumphost }}"
   tags: users
 
 - name: Only allow gateway ports from localhost


### PR DESCRIPTION
The NYC database depends on this.

The variable name ssh_tunnel_remote_user is very hard to understand or explain, because "remote" is ambiguous: remote from where?  We have three systems and therefore three different points of view.

This change adds two variables:

- `ssh_tunnel_gateway_user_on_jumphost` -- this is the login used by the gateway to the jumphost.
- `ssh_tunnel_ansible_user_on_jumphost` -- this is the login used by Ansible on the jumphost. It's really not needed at the moment, but I anticipate that it will be (if we create an admin user on the jumphost that might have shared credentials for the ops team).

It is possible that I overlooked some key things in examples -- those are tough because they're not used and therefore not testable.