### PR TITLE
Rework how LORA config files are generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 # Configuration Management of MultiTech Conduits as The Things Network Gateways
 
+**This branch is for testing changes to global configuration files and
+is not currently functional**
+
+**Some of the parameters obtained from Multitech configuration files
+do not work with the Kersing packet forwarder**
+
 This repo contains Ansible playbooks and configuration used to manage
 a group of [MultiTech MultiConnect®
 Conduit™](http://www.multitech.com/brands/multiconnect-conduit) and

--- a/bin/merge
+++ b/bin/merge
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import argparse
+import json
+import sys
+
+try:
+    import itertools.izip_longest as zip_longest
+except ImportError:
+    pass
+
+"""
+MIT License
+
+Copyright (c) 2018 Jeffrey C Honig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+def merge(a, b):
+    ''' https://stackoverflow.com/questions/19378143/python-merging-two-arbitrary-data-structures '''
+    if isinstance(a, dict) and isinstance(b, dict):
+        d = dict(a)
+        d.update({k: merge(a.get(k, None), b[k]) for k in b})
+        return d
+
+    if isinstance(a, list) and isinstance(b, list):
+        return [merge(x, y) for x, y in zip_longest(a, b)]
+
+    return a if b is None else b
+
+#
+#
+#
+def main():
+    """ Figure out what we should do """
+
+    parser = argparse.ArgumentParser(description="Merge JSON configuration files")
+
+    #	Debugging
+    group = parser.add_argument_group("Debugging options")
+    group.add_argument("-d", "--debug",
+                       dest="debug", default=False,
+                       action='store_true',
+                       help="print debugging messages")
+    group.add_argument("--nodebug",
+                       dest="debug",
+                       action='store_false',
+                       help="print debugging messages")
+    group.add_argument("-v", "--verbose",
+                       dest="verbose", default=False,
+                       action='store_true',
+                       help="print verbose messages")
+    group.add_argument("-n", "--noop",
+                       dest="noop", default=False,
+                       action='store_true',
+                       help="Don't make changes, just list what we are going to do")
+
+    group = parser.add_argument_group("Config options")
+    group.add_argument("-O", "--output",
+                       dest="output", default="-",
+                       help="Output file (defaults to stdout)")
+
+    group.add_argument("--include",
+                       dest="configs", nargs='+', action='append',
+                       help="A file name containing JSON followed by a list of first level keys to select")
+    group.add_argument("--file",
+                       dest="configs", action='append',
+                       help="The name of a file containing JSON")
+    group.add_argument("--json",
+                       dest="configs", action='append',
+                       help="JSON strings")
+
+    options = parser.parse_args()
+    if options.debug:
+        options.verbose = options.debug
+
+    result = dict()
+    for config in options.configs:
+        if options.debug:
+            print("PARSING: %s" % config)
+        if isinstance(config, list):
+            path = config[0]
+            sections = config[1:]
+        elif config.startswith('{'):
+            try:
+                data = json.loads(config)
+            except TypeError as error:
+                sys.exit("Error parsing %s: %s" % (data, error))
+            path = None
+            sections = None
+        else:
+            sections = None
+            path = config
+
+        if path is not None:
+            try:
+                fp = open(path)
+                data = json.load(fp)
+                fp.close()
+            except IOError as error:
+                sys.exit("Unable to open %s: %s" % (path, error))
+            except TypeError as error:
+                sys.exit("Error parsing %s: %s" % (path, error))
+
+        if sections is not None:
+            new_data = {}
+            for section in sections:
+                try:
+                    new_data[section] = data[section]
+                except KeyError:
+                    sys.exit("%s not found in %s" % (section, path))
+            data = new_data
+
+        result = merge(result, data)
+
+    if options.debug:
+        print("DBG: %s" % json.dumps(result, indent=4))
+
+    try:
+        if options.output == '-':
+            fp = sys.stdout
+        else:
+            fp = open(options.output, "w")
+        json.dump(result, fp, indent=4, sort_keys=True)
+    except IOError as error:
+        sys.exit("Unable to write %s: %s" % (options.output, error))
+
+    return 0
+
+if __name__ == "__main__":
+    try:
+        main()
+        sys.exit(0)
+    except KeyboardInterrupt:
+        print()
+        sys.exit(1)
+

--- a/bin/register
+++ b/bin/register
@@ -42,29 +42,15 @@ SOFTWARE.
 """
 
 register_url = "https://account.thethingsnetwork.org/users/authorize?client_id=ttnctl&redirect_uri=/oauth/callback/ttnctl&response_type=code"
-regions = {
-    "AS1": {
-        "plan": "AS_920_923"
-    },
-    "AS2": {
-        "plan": "AS_923_925"
-    },
-    "AU": {
-        "plan": "AU_915_928"
-    },
-    "EU": {
-        "plan": "EU_863_870"
-    },
-    "IN": {
-        "plan": "IN_865_867"
-    },
-    "KR": {
-        "plan": "KR_920_923"
-    },
-    "US": {
-        "plan": "US_902_928"
-    },
-}
+frequency_plans = [
+    "AS_920_923",
+    "AS_923_925",
+    "AU_915_928",
+    "EU_863_870",
+    "IN_865_867",
+    "KR_920_923",
+    "US_902_928",
+]
 
 #
 #	Gateway list
@@ -357,10 +343,10 @@ def main():
     group.add_argument("--old_id",
                        dest="old_id",
                        help="Old ID of Gateway to remove")
-    group.add_argument("--region",
-                       dest="region", required=True,
-		       choices=list(regions.keys()),
-                       help="Frequency region, one of %s" % ",".join(list(regions.keys())))
+    group.add_argument("--frequency_plan",
+                       dest="frequency_plan", required=True,
+		       choices=frequency_plans,
+                       help="Frequency plan")
     group.add_argument("--router", "--router-id",
                        dest="router",
                        choices=["",
@@ -401,12 +387,9 @@ def main():
     if options.debug:
         print("DBG: binary: %s" % options.binary, file=sys.stderr)
 
-    # Translate region into frequency plan
-    frequency_plan = regions[options.region].get('plan')
-
     if options.debug:
         print("DBG: ID: %s Frequency Plan: %s Location: %f, %f Router: %s" % (options.id,
-                                                                              frequency_plan,
+                                                                              options.frequency_plan,
                                                                               options.latitude,
                                                                               options.longitude,
                                                                               options.router),
@@ -435,9 +418,9 @@ def main():
     if options.id not in gateways:
         gateway = Gateway(options, options.id)
         gateways[options.id] = gateway
-        rc, output = gateway.register(frequency_plan, options.latitude, options.longitude, options.router)
+        rc, output = gateway.register(options.frequency_plan, options.latitude, options.longitude, options.router)
     if rc == 0:
-        rc, output = gateways[options.id].edit(frequency_plan, options.latitude, options.longitude, options.router)
+        rc, output = gateways[options.id].edit(options.frequency_plan, options.latitude, options.longitude, options.router)
     if rc == 0 and options.collaborators:
         rc, output = gateways[options.id].collaborators()
     if rc != 0:

--- a/group_vars/conduits-example.yml
+++ b/group_vars/conduits-example.yml
@@ -37,16 +37,33 @@ forwarder_version: 3.0.0-r14
 timezone: "US/Eastern"
 
 # Pick the correct region:
-# AS1	AS_920_923	Asia 1
-# AS2	AS_923_925	Asia 2
-# AU	AU_915_928	Australia
-# EU	EU_863_870	Europe
-# KR	KR_920_923	Korea
-# IN	IN_865_867	India
-# US	US_902_928	US
+# BN: "Brunei Darussalam"
+# EU: "Europe, Middle East, Russia and Africa"
+# HK: "Hong Kong"
+# ID: "Indonesia"
+# IN: "India"
+# JP: "Japan"
+# KH: "Cambodia"
+# LA: "Lao People's Democratic Republic"
+# MY: "Malaysia"
+# SG: "Signapore"
+# TH: "Thailand"
+# TW: "Taiwan, Province of China"
+# US: "North and South America"
+# VN: "Vietnam"
+# See regions in roles/conduit/defaults/main.yml for more info
 region: US
 
-# Pick a router ( switch-router ttn-router-asia-se ttn-router-brazil # ttn-router-eu ttn-router-us-west )
+# Select a router.  A default one is chosen for the region, but there
+# may be one that is more optimal for you gateways
+# digitalcatapult-uk-router
+# meshed-router
+# switch-router
+# ttn-router-asia-se
+# ttn-router-brazil
+# ttn-router-eu
+# ttn-router-jp
+# ttn-router-us-west
 router: ttn-router-us-west
 
 # Whom to contact about issues with this gateway

--- a/roles/conduit/defaults/main.yml
+++ b/roles/conduit/defaults/main.yml
@@ -71,3 +71,153 @@ gateway_collaborator_rights:
 use_gps: false
 gps_device: ttyXRUSB2
 
+# The following were taken from multitech_overrides.json in the
+#   mp-packet-forwarder package and are used if no multitech
+#   region-specific configuration is provided
+multitech_global_overrides: '--json {
+    "SX1301_conf": {
+        "clksrc_desc": "radio_0 provides clock to concentrator by default"
+        "clksrc": 0,
+    }
+}'
+
+# Source of the config files referenced below
+meta_mlinux_git: git://git.multitech.net/meta-mlinux
+meta_mlinux_version: 3.3.24
+meta_mlinux_root: "{{ role_path }}/files/meta-mlinux"
+meta_mlinux_confdir: "{{ meta_mlinux_root }}/recipes-connectivity/lora/lora-packet-forwarder"
+ttn_global_conf_root: "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master/"
+
+# See https://www.thethingsnetwork.org/docs/lorawan/frequencies-by-country.html
+regions:
+  AU:
+    desc: "Australia"
+    frequency_plan: AU_915_928
+    router: meshed_router
+  BN:
+    desc: "Brunei Darussalam"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  EU:
+    desc: "Europe, Middle East, Russia and Africa"
+    frequency_plan: EU_863_870
+    router: ttn-router-eu
+  HK:
+    desc: "Hong Kong"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  ID:
+    desc: "Indonesia"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  IN:
+    desc: "India"
+    frequency_plan: IN_865_867
+    router: ttn-router-asia-se
+  JP:
+    desc: "Japan"
+    frequency_plan: AS_920_923
+    router: ttn-router-jp
+  KH:
+    desc: "Cambodia"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  LA:
+    desc: "Lao People's Democratic Republic"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  MY:
+    desc: "Malaysia"
+    frequency_plan: AS_920_923
+    router: ttn-router-asia-se
+  SG:
+    desc: "Signapore"
+    frequency_plan: AS_920_923
+    router: ttn-router-asia-se
+  TH:
+    desc: "Thailand"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  TW:
+    desc: "Taiwan, Province of China"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+  UK:
+    desc: "United Kingdom"
+    frequency_plan: EU_863_870
+    router: digitalcatapult-uk-router
+  US:
+    desc: "North and South America"
+    frequency_plan: US_902_928
+    router: ttn-router-us-west
+  VN:
+    desc: "Vietnam"
+    frequency_plan: AS_923_925
+    router: ttn-router-asia-se
+
+frequency_plans:
+  AS_920_923:
+    product_ids:
+      - MTAC-LORA-915
+      - MTCAP-LORA-915
+      - MTAC-LORA-H-915
+    global_conf: AS1-global_conf.json
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.AS923-LBT.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.AS923-LBT.basic
+  AS_923_925:
+    product_ids:
+      - MTAC-LORA-915
+      - MTCAP-LORA-915
+      - MTAC-LORA-H-915
+    router: ttn-router-asia-se
+    global_conf: AS2-global_conf.json
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.AS923.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.AS923.basic
+  AU_915_928:
+    product_ids:
+      - MTAC-LORA-915
+      - MTCAP-LORA-915
+      - MTAC-LORA-H-915
+    router: ttn-router-asia-se
+    global_conf: AU-global_conf.json
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.AU915.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.AU915.basic
+  EU_863_870:
+    product_ids:
+      - MTAC-LORA-868
+      - MTCAP-LORA-868
+      - MTAC-LORA-H-868
+    router: ttn-router-eu
+    global_conf: EU-global_conf.json
+    "MTAC-LORA-1.0": global_conf.json.3.0.0.MTAC_LORA_1_0.EU868.basic.clksrc0
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.EU868.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.EU868.basic
+  IN_865_867:
+    product_ids:
+      - MTAC-LORA-868
+      - MTCAP-LORA-868
+      - MTAC-LORA-H-868
+    router: ttn-router-asia-se
+    global_conf: IN-global_conf.json
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.IN865.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.IN865.basic
+  KR_920_923:
+    product_ids:
+      - MTAC-LORA-915
+      - MTCAP-LORA-915
+      - MTAC-LORA-H-915
+    router: ttn-router-asia-se
+    global_conf: KR-global_conf.json
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.KR920-LBT.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.KR920-LBT.basic
+  US_902_928:
+    product_ids:
+      - MTAC-LORA-915
+      - MTCAP-LORA-915
+      - MTAC-LORA-H-915
+    router: ttn-router-us-west
+    global_conf: US-global_conf.json
+    "MTAC-LORA-1.0": global_conf.json.3.0.0.MTAC_LORA_1_0.US915.basic.clksrc0
+    "MTAC-LORA-1.5": global_conf.json.3.0.0.MTAC_LORA_1_5.US915.basic.clksrc0
+    "MTCAP-LORA-1.5": global_conf.json.3.1.0.MTCAP-LORA-1-5.US915.basic
+

--- a/roles/conduit/files/.gitignore
+++ b/roles/conduit/files/.gitignore
@@ -6,3 +6,4 @@
 /md5sums_*.txt
 /mlinux-factory-image-*-upgrade.bin_*
 /ttni-base-image-*-upgrade.bin_*
+/meta-mlinux

--- a/roles/conduit/tasks/ttn.yml
+++ b/roles/conduit/tasks/ttn.yml
@@ -4,11 +4,20 @@
 #	Register gateway
 #
 
-- name: Check if using correct card for the region
+- name: Validate region
   fail:
-    msg: "Lora card {{ ansible_local.lora.product_id }} and region {{region }} mismatch"
-  when: 
-    - ( ansible_local.lora.product_id is match("MTAC-LORA-(H-)?915") and region is match("EU|IN") ) or ( ansible_local.lora.product_id is match("MTAC-LORA-(H-)?868") and region is match("US|AU|AS1|AS2|KR") )
+    msg: "Unknown or invalid region: {{ region }}"
+  when: region not in regions
+
+- name: Look up frequency plan
+  set_fact:
+    frequency_plan: "{{ regions[region]['frequency_plan'] }}"
+
+- name: Validate product ID for region
+  fail:
+    msg: "{{ ansible_local.lora.product_id }} is not supported for region: {{ region }}"
+  when:
+    - ansible_local.lora.product_id not in frequency_plans[frequency_plan]['product_ids']
     - radio_mismatch is not defined
 
 - name: Check if using correct packet forwarder
@@ -30,11 +39,11 @@
     args:
       "bin/register
         --json
-        --id {{ lora_hostname }} 
-      	--region {{ region }}
+        --id {{ lora_hostname }}
+      	--frequency_plan {{ frequency_plan }}
         --latitude {{ latitude }}
         --longitude {{ longitude }}
-        --router {{ router }}
+        --router {{ router if router is defined else regions[region]['router'] }}
         --description {{ description | quote }}
         --brand {{ gateway_brand | quote }}
         --model {{ gateway_model | quote }}
@@ -77,7 +86,7 @@
 #	Install dependencies
 #
 - name: Install depedencies for packet forwarder
-  opkg: 
+  opkg:
     state: installed
     pkg: "{{ item }}"
   when: (ansible_local is not defined) or (ansible_local.opkg is not defined) or (item not in ansible_local.opkg.keys())
@@ -154,10 +163,39 @@
     - update rc
     - restart ttn-pkt-forwarder
 
-- name: Clean up packet-forwarder crud
-  file:
-    name: /var/config/lora/local_conf.json-opkg
-    state: absent
+- name: Grab mLinux meta-mlinux layer
+  local_action: git
+  args:
+    update: true
+    repo: "{{ meta_mlinux_git }}"
+    dest: "{{ meta_mlinux_root }}"
+    version: "{{ meta_mlinux_version }}"
+  run_once: true
+
+- name: Pick a MultiTech specific global configuration
+  set_fact:
+    multitech_global_conf: --include {{ meta_mlinux_confdir }}/{{frequency_plans[frequency_plan][ansible_local.lora.hw_version] }} SX1301_conf
+  when: ansible_local.lora.hw_version in frequency_plans[frequency_plan]
+
+- name: Pick a TTN region specific global configuration
+  set_fact:
+    ttn_global_conf: "{{ frequency_plans[frequency_plan]['global_conf'] }}"
+
+- name: Make sure we have the TTN region specific global configuration
+  local_action: get_url
+  args:
+    url: "{{ ttn_global_conf_root }}/{{ ttn_global_conf }}"
+    dest: "{{ role_path }}/files"
+  run_once: true
+
+- name: Generate target specific global_conf.json
+  local_action:
+    module: shell
+    args:
+      "bin/merge
+       -O {{ role_path }}/files/global_conf-{{ hostname }}.json
+       --include {{ role_path }}/files/{{ ttn_global_conf }} gateway_conf
+       {{ multitech_global_conf if multitech_global_conf is defined else multitech_global_overrides }}"
 
 #
 #	Install the TTN config files
@@ -169,28 +207,35 @@
     owner: root
     group: root
 
-- block:
-    - template:
-        src: local_conf.json.j2
-        dest: /var/config/lora/local_conf.json
-        mode: "0644"
-        owner: root
-        group: root
+- name: Install /var/config/lora/local_conf.json
+  template:
+    src: local_conf.json.j2
+    dest: /var/config/lora/local_conf.json
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - restart ttn-pkt-forwarder
 
-    - local_action: get_url
-      args:
-        url: "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master/{{ region }}-global_conf.json"
-        dest: "{{ role_path }}/files"
+- name: Install /var/config/loral/global_conf.json
+  copy:
+    src: "{{ role_path }}/files/global_conf-{{ hostname }}.json"
+    dest: /var/config/lora/global_conf.json
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - restart ttn-pkt-forwarder
 
-    - copy:
-        src: "{{ region }}-global_conf.json"
-        dest: /var/config/lora/ttn_global_conf.json
-        mode: "0644"
-        owner: root
-        group: root
-
-    - shell: node /opt/lora/merge.js /var/config/lora/ttn_global_conf.json /var/config/lora/multitech_overrides.json /var/config/lora/global_conf.json
-      notify: restart ttn-pkt-forwarder
+- name: Remove outdated config files
+  file:
+    name: "/var/config/lora/{{ item }}"
+    state: absent
+  loop:
+    - local_conf.json-opkg
+    - multitech_overrides.json
+    - samples
+    - ttn_global_conf.json
 
 - name: Remove TTN packet forwarder config
   file:

--- a/roles/conduit/templates/local_conf.json.j2
+++ b/roles/conduit/templates/local_conf.json.j2
@@ -22,7 +22,7 @@
 	"keepalive_interval": 10,
 	"stat_interval": 30,
 	"push_timeout_ms": 100,
-	"platform": "*"'
+	"platform": "*"',
 {# end of merged #}
 {% if forwarder_variant == "mp" %}
 	"servers": [

--- a/roles/conduit/templates/local_conf.json.j2
+++ b/roles/conduit/templates/local_conf.json.j2
@@ -13,6 +13,17 @@
         "ref_longitude": {{ longitude }},
         "ref_altitude": {{ altitude if altitude else -1 }},
 {% endif %}
+{# The following have been merged in from the multitech-overrides.json
+    provided with the mp-package-forwarder #}
+	"upstream": true,
+	"downstream": true,
+	"radiostream": true,
+	"statusstream": true,
+	"keepalive_interval": 10,
+	"stat_interval": 30,
+	"push_timeout_ms": 100,
+	"platform": "*"'
+{# end of merged #}
 {% if forwarder_variant == "mp" %}
 	"servers": [
             {

--- a/roles/conduit/templates/local_conf.json.j2
+++ b/roles/conduit/templates/local_conf.json.j2
@@ -22,7 +22,7 @@
 	"keepalive_interval": 10,
 	"stat_interval": 30,
 	"push_timeout_ms": 100,
-	"platform": "*"',
+	"platform": "*",
 {# end of merged #}
 {% if forwarder_variant == "mp" %}
 	"servers": [


### PR DESCRIPTION
Add the gateway_conf section from mp-packet-forwarder's
multitech_overrides.json into the local_conf.json.j2.

In general we ignore the SX1301_conf section from
multitech_overrides.json and use Multitech model and region specific
data from Multitech's meta-mlinux layer.  If there is not a specific
file we include a brief snipped that sets the default clock source.

Regions are now specified by country, see
group_vars/conduits-example.yaml.  Supported countries in Asia are
broken out, US is still all of North and South America.  EU covers
Russia, Middle East and Africa but there is a more specific UK region.

All creation of local_conf.json and global_conf.json is done on the
Ansible host, the later with a python script.  There is no longer a
need for node.js on the target.