### PR TITLE
Reset concentrator before starting forwarder

### DIFF
--- a/roles/conduit/templates/ttn-pkt-forwarder.j2
+++ b/roles/conduit/templates/ttn-pkt-forwarder.j2
@@ -104,6 +104,11 @@ do_start() {
 
     case ${pkt_fwd} in
 	/opt/lora/*)
+	    echo -n "Resetting concentrator: "
+	    /usr/sbin/mts-io-sysfs store lora/reset 0
+	    /usr/sbin/mts-io-sysfs store lora/reset 1
+	    sleep 1
+	    echo "DONE"
 	    if [ ! -f $conf_dir/global_conf.json -o ! -f $conf_dir/local_conf.json ] ; then
 		echo "$0: Not configured"
 		exit 1


### PR DESCRIPTION
https://github.com/IthacaThings/ttn-multitech-cm/issues/83

When starting the packet forwarder, reset the LoRA card.
 
On at least one GW, the concentrator would not start if we don't do this.