### PR TITLE
Fix #86: ssh_tunnel symlink must use filename

### DIFF
--- a/roles/conduit/tasks/ssh_tunnel.yml
+++ b/roles/conduit/tasks/ssh_tunnel.yml
@@ -47,11 +47,11 @@
   when:
     - ssh_tunnel_enabled
     
-- name: ssh_tunnel Link /etc/init.d/ssh_tunnel to /var/config/init.d/ssh_tunnel.init
+- name: ssh_tunnel Link /etc/init.d/ssh_tunnel to /var/config/init.d/ssh_tunnel
   file:
     dest: /etc/init.d/ssh_tunnel
     state: link
-    src: /var/config/init.d/ssh_tunnel.init
+    src: /var/config/init.d/ssh_tunnel
     force: yes
   notify: restart ssh_tunnel
   when:


### PR DESCRIPTION
I've decided I'm OK with the file name change, but the symlink doesn't currently match the file name. See suggested changes in attached.