### PR TITLE
Fix #91: install ppp at priority 02

### DIFF
--- a/roles/conduit/tasks/ppp.yml
+++ b/roles/conduit/tasks/ppp.yml
@@ -103,6 +103,12 @@
     - cellular_provider is defined
     - ppp0_mtu is defined
 
+- name: ppp remove previous PPP startup
+  command: update-rc.d -f ppp remove
+
+- name: ppp install proper PPP startup
+  command: update-rc.d ppp defaults 02
+
 #
 #	Monit
 #


### PR DESCRIPTION
Without something like this, boot w/cell w/o ethernet hangs at ntp startup because ppp isn't up.