### PR TITLE
Add `validate_certificates` variable for when we are behind a proxy

### DIFF
--- a/roles/conduit/defaults/main.yml
+++ b/roles/conduit/defaults/main.yml
@@ -193,3 +193,5 @@ monit_ppp_pidfile: "/var/run/{{ monit_ppp_if }}.pid"
 monit_ppp_initscript: "ppp"
 monit_ppp_start: '"/etc/init.d/{{ monit_ppp_initscript }} start" with timeout 15 seconds'
 monit_ppp_stop: '"/etc/init.d/{{ monit_ppp_initscript }} stop"'
+
+validate_certificates: true

--- a/roles/conduit/tasks/preserve.yml
+++ b/roles/conduit/tasks/preserve.yml
@@ -2,7 +2,7 @@
 
 - name: preserve Figure out if we need to ignore certificates on older versions
   set_fact:
-    validate_certs: "{{ ansible_local.mlinux.version is version('3.3.24', '>') }}"
+    validate_certs: "{{ validate_certificates and ansible_local.mlinux.version is version('3.3.24', '>') }}"
 
 - name: preserve Fetch preserve script
   get_url:


### PR DESCRIPTION
Set to `false` to allow insecure connections.

This is a short-term fix for a gateway behind an https proxy

https://github.com/IthacaThings/ttn-multitech-cm/issues/120